### PR TITLE
feat: Re-export modules from a main index file

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,0 +1,38 @@
+---
+title: index.ts
+nav_order: 3
+parent: Modules
+---
+
+# index overview
+
+Added in v3.1.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [datum](#datum)
+- [datumEither](#datumeither)
+
+---
+
+# datum
+
+**Signature**
+
+```ts
+typeof datum
+```
+
+Added in v3.1.0
+
+# datumEither
+
+**Signature**
+
+```ts
+typeof datumEither
+```
+
+Added in v3.1.0

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@nll/datum",
   "version": "3.0.3",
   "description": "ADT for handling fetchable and refreshable data",
+  "main": "index.js",
   "files": [
     "*"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @since 3.1.0
+ */
+
+import * as datum from './Datum';
+import * as datumEither from './DatumEither';
+
+export {
+  /**
+   * @since 3.1.0
+   */
+  datum,
+  /**
+   * @since 3.1.0
+   */
+  datumEither
+};

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,14 @@
+import * as assert from 'assert';
+import { datum, datumEither } from '../src';
+import * as Datum from '../src/Datum';
+import * as DatumEither from '../src/DatumEither';
+
+describe('Index', () => {
+  it('Re-exports the Datum module', () => {
+    assert.strictEqual(datum, Datum);
+  });
+
+  it('Re-exports the DatumEither module', () => {
+    assert.strictEqual(datumEither, DatumEither);
+  });
+});


### PR DESCRIPTION
Closes #4 
I double-checked the version number (`3.1.0`) used in the docstrings by running `npx standard-version --dry-run`

There might be some project configuration issues with regards to missing dev-dependencies, as I was getting the following error:

```sh
  ● Test suite failed to run

    Cannot find module '@babel/compat-data/corejs3-shipped-proposals'
```

and when trying to build the project

```sh
> ts-node --skip-project ./scripts/prepare.ts

Error: ENOENT: no such file or directory, stat './dist/src'
```

Making a PR to see if it works on CI

**EDIT:** Seems the issue was due to me running Node 13 locally. Switching to 12 fixed it.