### PR TITLE
fix: only depend on fp-ts/es6

### DIFF
--- a/src/DatumThese.ts
+++ b/src/DatumThese.ts
@@ -51,7 +51,7 @@ import { HKT } from 'fp-ts/es6/HKT';
 import { Semigroup } from 'fp-ts/es6/Semigroup';
 import { Monoid } from 'fp-ts/es6/Monoid';
 import { Traversable2 } from 'fp-ts/es6/Traversable';
-import { getTheseM, TheseM1 } from 'fp-ts/lib/TheseT';
+import { getTheseM, TheseM1 } from 'fp-ts/es6/TheseT';
 import { pipeable } from 'fp-ts/es6/pipeable';
 import { Functor2 } from 'fp-ts/es6/Functor';
 import { Apply2C } from 'fp-ts/es6/Apply';


### PR DESCRIPTION
… to avoid warnings in certain environments, such as @angular.

It appears all other imports reference `fp-ts/es6`, but there is one place that imports from `fp-ts/lib`